### PR TITLE
Replace deprecated license_file with license_files in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,8 @@ url = https://github.com/termcolor/termcolor
 author = Konstantin Lepa
 author_email = konstantin.lepa@gmail.com
 license = MIT
-license_file = COPYING.txt
+license_files =
+    COPYING.txt
 classifiers =
     Development Status :: 5 - Production/Stable
     Environment :: Console


### PR DESCRIPTION
Fixes error when building the project:

  .../site-packages/setuptools/config/setupcfg.py:463: SetuptoolsDeprecationWarning: The license_file parameter is deprecated, use license_files instead.

Documentation on the field:

https://setuptools.pypa.io/en/latest/userguide/declarative_config.html#metadata