### PR TITLE
Fix docstring for colored function

### DIFF
--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -101,16 +101,16 @@ def colored(
     """Colorize text.
 
     Available text colors:
-        red, green, yellow, blue, magenta, cyan, white.
+        grey, red, green, yellow, blue, magenta, cyan, white.
 
     Available text highlights:
-        on_red, on_green, on_yellow, on_blue, on_magenta, on_cyan, on_white.
+        on_grey, on_red, on_green, on_yellow, on_blue, on_magenta, on_cyan, on_white.
 
     Available attributes:
         bold, dark, underline, blink, reverse, concealed.
 
     Example:
-        colored('Hello, World!', 'red', 'on_grey', ['blue', 'blink'])
+        colored('Hello, World!', 'red', 'on_grey', ['bold', 'blink'])
         colored('Hello, World!', 'green')
     """
     if "NO_COLOR" in os.environ or "ANSI_COLORS_DISABLED" in os.environ:


### PR DESCRIPTION
The docstring for the function `colored` was missing the color `grey` and the highlight `on_grey`. The example used the non existing attribute `blue`. This has been replaced by `bold`.