### PR TITLE
Remove hardcoded VERSION constant

### DIFF
--- a/src/termcolor/__init__.py
+++ b/src/termcolor/__init__.py
@@ -1,21 +1,12 @@
 from __future__ import annotations
 
-from termcolor.termcolor import (
-    ATTRIBUTES,
-    COLORS,
-    HIGHLIGHTS,
-    RESET,
-    VERSION,
-    colored,
-    cprint,
-)
+from termcolor.termcolor import ATTRIBUTES, COLORS, HIGHLIGHTS, RESET, colored, cprint
 
 __all__ = [
     "ATTRIBUTES",
     "COLORS",
     "HIGHLIGHTS",
     "RESET",
-    "VERSION",
     "colored",
     "cprint",
 ]

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -29,8 +29,6 @@ from typing import Any, Iterable
 
 __ALL__ = ["colored", "cprint"]
 
-VERSION = (1, 1, 0)
-
 ATTRIBUTES = dict(
     list(
         zip(


### PR DESCRIPTION
To find the version, use:

```python
try:
    # Python 3.8+
    import importlib.metadata as importlib_metadata
except ImportError:
    # Python 3.7
    import importlib_metadata


print(importlib_metadata.version("termcolor"))
```

Docs: https://docs.python.org/3/library/importlib.metadata.html#distribution-versions
Backport: https://pypi.org/project/importlib-metadata/
