### PR TITLE
Autodeploy to TestPyPI and to PyPI for GH releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    if: github.repository_owner == 'termcolor'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install -U pip
+          python -m pip install -U build twine wheel
+
+      - name: Build package
+        run: |
+          python setup.py --version
+          python -m build
+          twine check --strict dist/*
+
+      - name: Publish package to PyPI
+        if: github.event.action == 'published'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
+      - name: Publish package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,23 @@
+# Release Checklist
+
+- [ ] Get `main` to the appropriate code release state.
+      [GitHub Actions](https://github.com/termcolor/termcolor/actions) should be running
+      cleanly for all merges to `main`.
+      [![GitHub Actions status](https://github.com/termcolor/termcolor/workflows/Test/badge.svg)](https://github.com/termcolor/termcolor/actions)
+
+- [ ] Edit release draft, adjust text if needed:
+      https://github.com/termcolor/termcolor/releases
+
+- [ ] Check next tag is correct, amend if needed
+
+- [ ] Publish release
+
+- [ ] Check the tagged
+      [GitHub Actions build](https://github.com/termcolor/termcolor/actions/workflows/deploy.yml)
+      has deployed to [PyPI](https://pypi.org/project/termcolor/#history)
+
+- [ ] Check installation:
+
+```bash
+pip3 uninstall -y termcolor && pip3 install -U termcolor && python -c "from termcolor import cprint; cprint('done', 'green')"
+```


### PR DESCRIPTION
Using https://github.com/pypa/gh-action-pypi-publish and 2FA tokens:

Deploy to PyPI for GitHub releases.

Also deploy to TestPyPI for merges to `main`.

And add a release checklist.