### PR TITLE
Update source URL

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ tests = [
 [project.urls]
 Changelog = "https://github.com/termcolor/termcolor/releases"
 Homepage = "https://github.com/termcolor/termcolor"
-Source = "https://github.com/hugovk/termcolor"
+Source = "https://github.com/termcolor/termcolor"
 
 
 [tool.black]


### PR DESCRIPTION
Since both the changelog and homepage are pointing to termcolor/termcolor, it would be weird to see the source located elsewhere.