### PR TITLE
Deprecate `__ALL__`, use `__all__` instead

### DIFF
--- a/src/termcolor/__init__.py
+++ b/src/termcolor/__init__.py
@@ -1,3 +1,4 @@
+"""ANSI color formatting for output in terminal."""
 from __future__ import annotations
 
 from termcolor.termcolor import ATTRIBUTES, COLORS, HIGHLIGHTS, RESET, colored, cprint

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -156,7 +156,7 @@ def cprint(
 
 
 if __name__ == "__main__":
-    print("Current terminal type: %s" % os.getenv("TERM"))
+    print(f"Current terminal type: {os.getenv('TERM')}")
     print("Test basic colors:")
     cprint("Grey color", "grey")
     cprint("Red color", "red")

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -25,9 +25,21 @@
 from __future__ import annotations
 
 import os
+import warnings
 from typing import Any, Iterable
 
-__ALL__ = ["colored", "cprint"]
+
+def __getattr__(name: str) -> list[str]:
+    if name == "__ALL__":
+        warnings.warn(
+            "__ALL__ is deprecated and will be removed in termcolor 3. "
+            "Use __all__ instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return ["colored", "cprint"]
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
 
 ATTRIBUTES = dict(
     list(

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import pytest
 
-from termcolor import ATTRIBUTES, COLORS, HIGHLIGHTS, colored, cprint
+from termcolor import ATTRIBUTES, COLORS, HIGHLIGHTS, colored, cprint, termcolor
 
 ALL_COLORS = [*COLORS, None]
 ALL_HIGHLIGHTS = [*HIGHLIGHTS, None]
@@ -119,9 +119,15 @@ def test_attrs(capsys: pytest.CaptureFixture[str], attr: str, expected: str) -> 
         "",
     ],
 )
-def test_env_var(
+def test_environment_variables(
     monkeypatch: pytest.MonkeyPatch, test_env_var: str, test_value: str
 ) -> None:
     """Assert nothing applied when this env var set, regardless of value."""
     monkeypatch.setenv(test_env_var, test_value)
     assert colored("text", color="red") == "text"
+
+
+def test_all_deprecation() -> None:
+    """Assert that __ALL__ is deprecated (use __all__ instead)"""
+    with pytest.deprecated_call():
+        assert termcolor.__ALL__


### PR DESCRIPTION
Re: https://github.com/hfeeki/termcolor/pull/3

`__ALL__` should be lowercase: https://docs.python.org/3/tutorial/modules.html#importing-from-a-package

Let's deprecate the old one and remove it in the next major bump.

An up-to-date `__all__` is in `__init__.py`

---

Also convert a `%` formatting to f-string, and add module docstring.