### PR TITLE
Support `FORCE_COLOR`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.2
+    rev: v3.1.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         args: [--target-version=py37]
@@ -39,7 +39,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.981
+    rev: v0.982
     hooks:
       - id: mypy
         args: [--strict, --pretty, --show-error-codes]
@@ -61,7 +61,7 @@ repos:
       - id: tox-ini-fmt
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.0
+    rev: v3.0.0-alpha.3
     hooks:
       - id: prettier
         args: [--prose-wrap=always, --print-width=88]

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -25,6 +25,7 @@
 from __future__ import annotations
 
 import os
+import sys
 import warnings
 from typing import Any, Iterable
 
@@ -123,7 +124,11 @@ def colored(
         colored('Hello, World!', 'red', 'on_grey', ['bold', 'blink'])
         colored('Hello, World!', 'green')
     """
-    if "NO_COLOR" in os.environ or "ANSI_COLORS_DISABLED" in os.environ:
+    if (
+        "NO_COLOR" in os.environ
+        or "ANSI_COLORS_DISABLED" in os.environ
+        or not sys.stdout.isatty()
+    ):
         return text
 
     fmt_str = "\033[%dm%s"

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -103,6 +103,21 @@ COLORS = dict(
 RESET = "\033[0m"
 
 
+def _can_do_colour() -> bool:
+    """Check env vars and for tty/dumb terminal"""
+    if "ANSI_COLORS_DISABLED" in os.environ:
+        return False
+    if "NO_COLOR" in os.environ:
+        return False
+    if "FORCE_COLOR" in os.environ:
+        return True
+    return (
+        hasattr(sys.stdout, "isatty")
+        and sys.stdout.isatty()
+        and os.environ.get("TERM") != "dumb"
+    )
+
+
 def colored(
     text: str,
     color: str | None = None,
@@ -124,11 +139,7 @@ def colored(
         colored('Hello, World!', 'red', 'on_grey', ['bold', 'blink'])
         colored('Hello, World!', 'green')
     """
-    if (
-        "NO_COLOR" in os.environ
-        or "ANSI_COLORS_DISABLED" in os.environ
-        or not sys.stdout.isatty()
-    ):
+    if not _can_do_colour():
         return text
 
     fmt_str = "\033[%dm%s"

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -14,10 +14,11 @@ ALL_ATTRIBUTES = [*ATTRIBUTES, None]
 
 def setup_module() -> None:
     # By default, make sure no env vars already set for tests
-    try:
-        del os.environ["ANSI_COLORS_DISABLED"]
-    except KeyError:  # pragma: no cover
-        pass
+    for var in ("ANSI_COLORS_DISABLED", "NO_COLOR", "FORCE_COLOR"):
+        try:
+            del os.environ[var]
+        except KeyError:  # pragma: no cover
+            pass
 
 
 def test_basic(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -157,6 +157,46 @@ def test_environment_variables_disable_color(
 
 
 @pytest.mark.parametrize(
+    "test_value",
+    [
+        "true",
+        "false",
+        "1",
+        "0",
+        "",
+    ],
+)
+def test_environment_variables_force_color(
+    monkeypatch: pytest.MonkeyPatch, test_value: str
+) -> None:
+    """Assert color applied when this env var set, regardless of value"""
+    monkeypatch.setenv("FORCE_COLOR", test_value)
+    assert colored("text", color="cyan") == "\x1b[36mtext\x1b[0m"
+
+
+@pytest.mark.parametrize(
+    "test_env_vars, expected",
+    [
+        (["ANSI_COLORS_DISABLED=1"], False),
+        (["NO_COLOR=1"], False),
+        (["FORCE_COLOR=1"], True),
+        (["ANSI_COLORS_DISABLED=1", "NO_COLOR=1", "FORCE_COLOR=1"], False),
+        (["NO_COLOR=1", "FORCE_COLOR=1"], False),
+    ],
+)
+def test_environment_variables(
+    monkeypatch: pytest.MonkeyPatch, test_env_vars: str, expected: bool
+) -> None:
+    """Assert combinations do the right thing"""
+    for env_var in test_env_vars:
+        name, value = env_var.split("=")
+        print(name, value)
+        monkeypatch.setenv(name, value)
+
+    assert termcolor._can_do_colour() == expected
+
+
+@pytest.mark.parametrize(
     "test_isatty, expected",
     [
         (True, "\x1b[36mtext\x1b[0m"),

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ passenv =
 extras =
     tests
 commands =
-    {envpython} -m pytest --cov termcolor --cov tests --cov-report xml {posargs}
+    {envpython} -m pytest --cov termcolor --cov tests --cov-report html --cov-report xml {posargs}
 
 [testenv:lint]
 passenv =


### PR DESCRIPTION
Fixes https://github.com/termcolor/termcolor/issues/2.

In the absence of special env vars, colour is enabled used when we're attached to a tty, that isn't a dumb terminal.

Normally we don't want to use colour for non-tty, like when piping output.

But GitHub Actions is also [not a tty](https://github.com/actions/runner/issues/241) and supports colour, so add support for `FORCE_COLOR`, which follows similar runes to [`NO_COLOR`](https://no-color.org/), to allow colour logging.

