### PR TITLE
Add `no_color` and `force_color` parameters to override env vars

### DIFF
--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -96,8 +96,22 @@ COLORS = {
 RESET = "\033[0m"
 
 
-def _can_do_colour() -> bool:
+def _can_do_colour(
+    *, no_color: bool | None = None, force_color: bool | None = None
+) -> bool:
     """Check env vars and for tty/dumb terminal"""
+    # First check overrides:
+    # "User-level configuration files and per-instance command-line arguments should
+    # override $NO_COLOR. A user should be able to export $NO_COLOR in their shell
+    # configuration file as a default, but configure a specific program in its
+    # configuration file to specifically enable color."
+    # https://no-color.org
+    if no_color is not None and no_color:
+        return False
+    if force_color is not None and force_color:
+        return True
+
+    # Then check env vars:
     if "ANSI_COLORS_DISABLED" in os.environ:
         return False
     if "NO_COLOR" in os.environ:
@@ -116,6 +130,9 @@ def colored(
     color: str | None = None,
     on_color: str | None = None,
     attrs: Iterable[str] | None = None,
+    *,
+    no_color: bool | None = None,
+    force_color: bool | None = None,
 ) -> str:
     """Colorize text.
 
@@ -136,7 +153,7 @@ def colored(
         colored('Hello, World!', 'red', 'on_black', ['bold', 'blink'])
         colored('Hello, World!', 'green')
     """
-    if not _can_do_colour():
+    if not _can_do_colour(no_color=no_color, force_color=force_color):
         return text
 
     fmt_str = "\033[%dm%s"
@@ -158,11 +175,26 @@ def cprint(
     color: str | None = None,
     on_color: str | None = None,
     attrs: Iterable[str] | None = None,
+    *,
+    no_color: bool | None = None,
+    force_color: bool | None = None,
     **kwargs: Any,
 ) -> None:
-    """Print colorize text.
+    """Print colorized text.
 
     It accepts arguments of print function.
     """
 
-    print((colored(text, color, on_color, attrs)), **kwargs)
+    print(
+        (
+            colored(
+                text,
+                color,
+                on_color,
+                attrs,
+                no_color=no_color,
+                force_color=force_color,
+            )
+        ),
+        **kwargs,
+    )

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -36,6 +36,10 @@ def test_sanity() -> None:
                 attrs = None if attribute is None else [attribute]
                 colored("text", color, highlight, attrs)
                 cprint("text", color, highlight, attrs)
+                colored("text", color, highlight, attrs, no_color=True)
+                cprint("text", color, highlight, attrs, no_color=True)
+                colored("text", color, highlight, attrs, force_color=True)
+                cprint("text", color, highlight, attrs, force_color=True)
 
 
 def assert_cprint(
@@ -184,25 +188,46 @@ def test_environment_variables_force_color(
 
 
 @pytest.mark.parametrize(
-    "test_env_vars, expected",
+    "test_no_color, test_force_color, test_env_vars, expected",
     [
-        (["ANSI_COLORS_DISABLED=1"], False),
-        (["NO_COLOR=1"], False),
-        (["FORCE_COLOR=1"], True),
-        (["ANSI_COLORS_DISABLED=1", "NO_COLOR=1", "FORCE_COLOR=1"], False),
-        (["NO_COLOR=1", "FORCE_COLOR=1"], False),
+        # Set only env vars
+        (None, None, ["ANSI_COLORS_DISABLED=1"], False),
+        (None, None, ["NO_COLOR=1"], False),
+        (None, None, ["FORCE_COLOR=1"], True),
+        (None, None, ["ANSI_COLORS_DISABLED=1", "NO_COLOR=1", "FORCE_COLOR=1"], False),
+        (None, None, ["NO_COLOR=1", "FORCE_COLOR=1"], False),
+        # Set only parameter overrides
+        (True, None, [None], False),
+        (None, True, [None], True),
+        (True, True, [None], False),
+        # Set both parameter overrides and env vars
+        (True, None, ["NO_COLOR=1"], False),
+        (None, True, ["NO_COLOR=1"], True),
+        (True, True, ["NO_COLOR=1"], False),
+        (True, None, ["FORCE_COLOR=1"], False),
+        (None, True, ["FORCE_COLOR=1"], True),
+        (True, True, ["FORCE_COLOR=1"], False),
     ],
 )
 def test_environment_variables(
-    monkeypatch: pytest.MonkeyPatch, test_env_vars: str, expected: bool
+    monkeypatch: pytest.MonkeyPatch,
+    test_no_color: bool,
+    test_force_color: bool,
+    test_env_vars: str,
+    expected: bool,
 ) -> None:
     """Assert combinations do the right thing"""
     for env_var in test_env_vars:
+        if not env_var:
+            continue
         name, value = env_var.split("=")
         print(name, value)
         monkeypatch.setenv(name, value)
 
-    assert termcolor._can_do_colour() == expected
+    assert (
+        termcolor._can_do_colour(no_color=test_no_color, force_color=test_force_color)
+        == expected
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/termcolor/termcolor/issues/33, https://github.com/termcolor/termcolor/issues/28#issuecomment-1354537992, https://github.com/termcolor/termcolor/issues/2#issuecomment-1287010438.

https://no-color.org/ says (command-line) arguments should override the environment variables:

> 2. **How should configuration files and command-line arguments be processed in the presence of `$NO_COLOR`?**
>
> User-level configuration files and per-instance command-line arguments should override `$NO_COLOR`. A user should be able to export `$NO_COLOR` in their shell configuration file as a default, but configure a specific program in its configuration file to specifically enable color.
>
> This also means that software that can add color but doesn’t by default does not need to care about `$NO_COLOR`, because it will only ever be adding color when instructed to do so (as it should be).

Add both `no_color` and `force_color` parameters.

The `no_color` parameter takes priority over `force_color`, and both parameters take priority over the environment variables.
