### PR TITLE
Improve typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ classifiers = [
 dynamic = [
   "version",
 ]
+dependencies = [
+  'typing-extensions>=4.5; python_version < "3.8"',
+]
 [project.optional-dependencies]
 tests = [
   "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,6 @@ classifiers = [
 dynamic = [
   "version",
 ]
-dependencies = [
-  'typing-extensions>=4.5; python_version < "3.8"',
-]
 [project.optional-dependencies]
 tests = [
   "pytest",

--- a/src/termcolor/_types.py
+++ b/src/termcolor/_types.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Literal
+
+Attribute = Literal[
+    "bold",
+    "dark",
+    "underline",
+    "blink",
+    "reverse",
+    "concealed",
+]
+
+Highlight = Literal[
+    "on_black",
+    "on_grey",
+    "on_red",
+    "on_green",
+    "on_yellow",
+    "on_blue",
+    "on_magenta",
+    "on_cyan",
+    "on_light_grey",
+    "on_dark_grey",
+    "on_light_red",
+    "on_light_green",
+    "on_light_yellow",
+    "on_light_blue",
+    "on_light_magenta",
+    "on_light_cyan",
+    "on_white",
+]
+
+Color = Literal[
+    "black",
+    "grey",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "light_grey",
+    "dark_grey",
+    "light_red",
+    "light_green",
+    "light_yellow",
+    "light_blue",
+    "light_magenta",
+    "light_cyan",
+    "white",
+]

--- a/src/termcolor/_types.py
+++ b/src/termcolor/_types.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import sys
-
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
+from typing import Literal
 
 Attribute = Literal[
     "bold",

--- a/src/termcolor/_types.py
+++ b/src/termcolor/_types.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from typing import Literal
+import sys
+
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 Attribute = Literal[
     "bold",

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -29,6 +29,8 @@ import sys
 import warnings
 from typing import Any, Iterable
 
+from ._types import Attribute, Color, Highlight
+
 
 def __getattr__(name: str) -> list[str]:
     if name == "__ALL__":
@@ -43,7 +45,7 @@ def __getattr__(name: str) -> list[str]:
     raise AttributeError(msg)
 
 
-ATTRIBUTES = {
+ATTRIBUTES: dict[Attribute, int] = {
     "bold": 1,
     "dark": 2,
     "underline": 4,
@@ -52,8 +54,7 @@ ATTRIBUTES = {
     "concealed": 8,
 }
 
-
-HIGHLIGHTS = {
+HIGHLIGHTS: dict[Highlight, int] = {
     "on_black": 40,
     "on_grey": 40,  # Actually black but kept for backwards compatibility
     "on_red": 41,
@@ -73,7 +74,7 @@ HIGHLIGHTS = {
     "on_white": 107,
 }
 
-COLORS = {
+COLORS: dict[Color, int] = {
     "black": 30,
     "grey": 30,  # Actually black but kept for backwards compatibility
     "red": 31,
@@ -128,9 +129,9 @@ def _can_do_colour(
 
 def colored(
     text: str,
-    color: str | None = None,
-    on_color: str | None = None,
-    attrs: Iterable[str] | None = None,
+    color: Color | None = None,
+    on_color: Highlight | None = None,
+    attrs: Iterable[Attribute] | None = None,
     *,
     no_color: bool | None = None,
     force_color: bool | None = None,
@@ -173,9 +174,9 @@ def colored(
 
 def cprint(
     text: str,
-    color: str | None = None,
-    on_color: str | None = None,
-    attrs: Iterable[str] | None = None,
+    color: Color | None = None,
+    on_color: Highlight | None = None,
+    attrs: Iterable[Attribute] | None = None,
     *,
     no_color: bool | None = None,
     force_color: bool | None = None,

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -128,7 +128,7 @@ def _can_do_colour(
 
 
 def colored(
-    text: str,
+    text: object,
     color: Color | None = None,
     on_color: Highlight | None = None,
     attrs: Iterable[Attribute] | None = None,
@@ -155,25 +155,25 @@ def colored(
         colored('Hello, World!', 'red', 'on_black', ['bold', 'blink'])
         colored('Hello, World!', 'green')
     """
-    if not _can_do_colour(no_color=no_color, force_color=force_color):
-        return text
+    result = str(text)
+    if _can_do_colour(no_color=no_color, force_color=force_color):
+        fmt_str = "\033[%dm%s"
+        if color is not None:
+            result = fmt_str % (COLORS[color], result)
 
-    fmt_str = "\033[%dm%s"
-    if color is not None:
-        text = fmt_str % (COLORS[color], text)
+        if on_color is not None:
+            result = fmt_str % (HIGHLIGHTS[on_color], result)
 
-    if on_color is not None:
-        text = fmt_str % (HIGHLIGHTS[on_color], text)
+        if attrs is not None:
+            for attr in attrs:
+                result = fmt_str % (ATTRIBUTES[attr], result)
 
-    if attrs is not None:
-        for attr in attrs:
-            text = fmt_str % (ATTRIBUTES[attr], text)
-
-    return text + RESET
+        result += RESET
+    return result
 
 
 def cprint(
-    text: str,
+    text: object,
     color: Color | None = None,
     on_color: Highlight | None = None,
     attrs: Iterable[Attribute] | None = None,

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -156,19 +156,22 @@ def colored(
         colored('Hello, World!', 'green')
     """
     result = str(text)
-    if _can_do_colour(no_color=no_color, force_color=force_color):
-        fmt_str = "\033[%dm%s"
-        if color is not None:
-            result = fmt_str % (COLORS[color], result)
+    if not _can_do_colour(no_color=no_color, force_color=force_color):
+        return result
 
-        if on_color is not None:
-            result = fmt_str % (HIGHLIGHTS[on_color], result)
+    fmt_str = "\033[%dm%s"
+    if color is not None:
+        result = fmt_str % (COLORS[color], result)
 
-        if attrs is not None:
-            for attr in attrs:
-                result = fmt_str % (ATTRIBUTES[attr], result)
+    if on_color is not None:
+        result = fmt_str % (HIGHLIGHTS[on_color], result)
 
-        result += RESET
+    if attrs is not None:
+        for attr in attrs:
+            result = fmt_str % (ATTRIBUTES[attr], result)
+
+    result += RESET
+
     return result
 
 

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import os
-from typing import Any
+from typing import Any, Iterable
 
 import pytest
 
 from termcolor import ATTRIBUTES, COLORS, HIGHLIGHTS, colored, cprint, termcolor
+from termcolor._types import Attribute, Color, Highlight
 
 ALL_COLORS = [*COLORS, None]
 ALL_HIGHLIGHTS = [*HIGHLIGHTS, None]
@@ -46,9 +47,9 @@ def assert_cprint(
     capsys: pytest.CaptureFixture[str],
     expected: str,
     text: str,
-    color: str | None = None,
-    on_color: str | None = None,
-    attrs: list[str] | None = None,
+    color: Color | None = None,
+    on_color: Highlight | None = None,
+    attrs: Iterable[Attribute] | None = None,
     **kwargs: Any,
 ) -> None:
     cprint(text, color, on_color, attrs, **kwargs)
@@ -77,7 +78,7 @@ def assert_cprint(
 def test_color(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
-    color: str,
+    color: Color,
     expected: str,
 ) -> None:
     # Arrange
@@ -108,7 +109,7 @@ def test_color(
 def test_on_color(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
-    on_color: str,
+    on_color: Highlight,
     expected: str,
 ) -> None:
     # Arrange
@@ -133,7 +134,7 @@ def test_on_color(
 def test_attrs(
     capsys: pytest.CaptureFixture[str],
     monkeypatch: pytest.MonkeyPatch,
-    attr: str,
+    attr: Attribute,
     expected: str,
 ) -> None:
     # Arrange


### PR DESCRIPTION
This PR introduces two changes to the declared type signatures:
1. The allowed colors, highlights, and attributes are now checked against defined string literals. This means that, e.g., `cprint("hello", "orange")` will result in
   ```
   error: Argument 2 to "cprint" has incompatible type "Literal['orange']"; expected "Optional[Literal['black', 'grey', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'light_grey', 'dark_grey', 'light_red', 'light_green', 'light_yellow', 'light_blue', 'light_magenta', 'light_cyan', 'white']]"
   ```
   when using type checker.
2. The type of first argument of `colored` and `cprint` was relaxed to accept `object`s and not just `str`ings. This makes `cprint` more in line with `print`, which accepts arbitrary objects and fixes the example in README which reads
    ```python
    for i in range(10):
        cprint(i, "magenta", end=" ")
    ```
    which currently results in `error: Argument 1 to "cprint" has incompatible type "int"; expected "str"` when running through mypy.