### PR TITLE
Improve `isatty` check

### DIFF
--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -24,6 +24,7 @@
 
 from __future__ import annotations
 
+import io
 import os
 import sys
 import warnings
@@ -127,7 +128,7 @@ def _can_do_colour(
             and os.isatty(sys.stdout.fileno())
             and os.environ.get("TERM") != "dumb"
         )
-    except:
+    except io.UnsupportedOperation:
         return (
             hasattr(sys.stdout, "isatty")
             and sys.stdout.isatty()

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -122,9 +122,18 @@ def _can_do_colour(
         return True
 
     try:
-        return hasattr(sys.stdout, "fileno") and os.isatty(sys.stdout.fileno()) and os.environ.get("TERM") != "dumb"
+        return (
+            hasattr(sys.stdout, "fileno")
+            and os.isatty(sys.stdout.fileno())
+            and os.environ.get("TERM") != "dumb"
+        )
     except:
-        return hasattr(sys.stdout, "isatty") and sys.stdout.isatty() and os.environ.get("TERM") != "dumb"
+        return (
+            hasattr(sys.stdout, "isatty")
+            and sys.stdout.isatty()
+            and os.environ.get("TERM") != "dumb"
+        )
+
 
 def colored(
     text: object,

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -120,12 +120,12 @@ def _can_do_colour(
         return False
     if "FORCE_COLOR" in os.environ:
         return True
+
     return (
-        hasattr(sys.stdout, "isatty")
-        and sys.stdout.isatty()
+        hasattr(sys.stdout, "fileno")
+        and sys.stdout.fileno()
         and os.environ.get("TERM") != "dumb"
     )
-
 
 def colored(
     text: object,

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -122,18 +122,16 @@ def _can_do_colour(
     if "FORCE_COLOR" in os.environ:
         return True
 
+    # Then check system:
+    if os.environ.get("TERM") == "dumb":
+        return False
+    if not hasattr(sys.stdout, "fileno"):
+        return False
+
     try:
-        return (
-            hasattr(sys.stdout, "fileno")
-            and os.isatty(sys.stdout.fileno())
-            and os.environ.get("TERM") != "dumb"
-        )
+        return os.isatty(sys.stdout.fileno())
     except io.UnsupportedOperation:
-        return (
-            hasattr(sys.stdout, "isatty")
-            and sys.stdout.isatty()
-            and os.environ.get("TERM") != "dumb"
-        )
+        return sys.stdout.isatty()
 
 
 def colored(

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -121,11 +121,10 @@ def _can_do_colour(
     if "FORCE_COLOR" in os.environ:
         return True
 
-    return (
-        hasattr(sys.stdout, "fileno")
-        and sys.stdout.fileno()
-        and os.environ.get("TERM") != "dumb"
-    )
+    try:
+        return hasattr(sys.stdout, "fileno") and os.isatty(sys.stdout.fileno()) and os.environ.get("TERM") != "dumb"
+    except:
+        return hasattr(sys.stdout, "isatty") and sys.stdout.isatty() and os.environ.get("TERM") != "dumb"
 
 def colored(
     text: object,

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import os
+import os, sys
 from typing import Any, Iterable
 
 import pytest
@@ -24,7 +24,9 @@ def setup_module() -> None:
 
 def test_basic(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text") == "text\x1b[0m"
@@ -82,7 +84,9 @@ def test_color(
     expected: str,
 ) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text", color=color) == expected
@@ -113,7 +117,9 @@ def test_on_color(
     expected: str,
 ) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text", on_color=on_color) == expected
@@ -138,7 +144,9 @@ def test_attrs(
     expected: str,
 ) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text", attrs=[attr]) == expected
@@ -241,7 +249,9 @@ def test_environment_variables(
 def test_tty(monkeypatch: pytest.MonkeyPatch, test_isatty: bool, expected: str) -> None:
     """Assert color when attached to tty, no color when not attached"""
     # Arrange
-    monkeypatch.setattr("sys.stdout.fileno", lambda: test_isatty)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: test_isatty)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
+    monkeypatch.setattr(os, "isatty", lambda fd: test_isatty)
 
     # Act / Assert
     assert colored("text", color="cyan") == expected

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-import os, sys
+import os
+import sys
 from typing import Any, Iterable
 
 import pytest

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -24,9 +24,9 @@ def setup_module() -> None:
 
 def test_basic(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
-    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text") == "text\x1b[0m"
@@ -84,9 +84,9 @@ def test_color(
     expected: str,
 ) -> None:
     # Arrange
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
-    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text", color=color) == expected
@@ -117,9 +117,9 @@ def test_on_color(
     expected: str,
 ) -> None:
     # Arrange
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
-    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text", on_color=on_color) == expected
@@ -144,9 +144,9 @@ def test_attrs(
     expected: str,
 ) -> None:
     # Arrange
+    monkeypatch.setattr(os, "isatty", lambda fd: True)
     monkeypatch.setattr("sys.stdout.isatty", lambda: True)
     monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
-    monkeypatch.setattr(os, "isatty", lambda fd: True)
 
     # Act / Assert
     assert colored("text", attrs=[attr]) == expected
@@ -249,9 +249,9 @@ def test_environment_variables(
 def test_tty(monkeypatch: pytest.MonkeyPatch, test_isatty: bool, expected: str) -> None:
     """Assert color when attached to tty, no color when not attached"""
     # Arrange
+    monkeypatch.setattr(os, "isatty", lambda fd: test_isatty)
     monkeypatch.setattr("sys.stdout.isatty", lambda: test_isatty)
     monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
-    monkeypatch.setattr(os, "isatty", lambda fd: test_isatty)
 
     # Act / Assert
     assert colored("text", color="cyan") == expected

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -24,7 +24,7 @@ def setup_module() -> None:
 
 def test_basic(monkeypatch: pytest.MonkeyPatch) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
 
     # Act / Assert
     assert colored("text") == "text\x1b[0m"
@@ -82,7 +82,7 @@ def test_color(
     expected: str,
 ) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
 
     # Act / Assert
     assert colored("text", color=color) == expected
@@ -113,7 +113,7 @@ def test_on_color(
     expected: str,
 ) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
 
     # Act / Assert
     assert colored("text", on_color=on_color) == expected
@@ -138,7 +138,7 @@ def test_attrs(
     expected: str,
 ) -> None:
     # Arrange
-    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: True)
 
     # Act / Assert
     assert colored("text", attrs=[attr]) == expected
@@ -241,7 +241,7 @@ def test_environment_variables(
 def test_tty(monkeypatch: pytest.MonkeyPatch, test_isatty: bool, expected: str) -> None:
     """Assert color when attached to tty, no color when not attached"""
     # Arrange
-    monkeypatch.setattr("sys.stdout.isatty", lambda: test_isatty)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: test_isatty)
 
     # Act / Assert
     assert colored("text", color="cyan") == expected

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -205,6 +205,7 @@ def test_environment_variables_force_color(
         (None, None, ["FORCE_COLOR=1"], True),
         (None, None, ["ANSI_COLORS_DISABLED=1", "NO_COLOR=1", "FORCE_COLOR=1"], False),
         (None, None, ["NO_COLOR=1", "FORCE_COLOR=1"], False),
+        (None, None, ["TERM=dumb"], False),
         # Set only parameter overrides
         (True, None, [None], False),
         (None, True, [None], True),
@@ -230,7 +231,7 @@ def test_environment_variables(
         if not env_var:
             continue
         name, value = env_var.split("=")
-        print(name, value)
+        print(f"{name}={value}")
         monkeypatch.setenv(name, value)
 
     assert (

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from typing import Any, Iterable
 
 import pytest


### PR DESCRIPTION
- use `os.isatty(sys.stdout.fileno())` is much better than `sys.stdout.isatty()`

Fixed:
- #40 
- #41 