### PR TITLE
Lint with faster action-pre-commit-uv: 1m22s -> 48s and 21s -> 15s

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   FORCE_COLOR: 1
-  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 permissions:
   contents: read
@@ -18,5 +17,4 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-          cache: pip
-      - uses: pre-commit/action@v3.0.1
+      - uses: tox-dev/action-pre-commit-uv@v1


### PR DESCRIPTION
# pre-commit/action

Without cache: 1m 22s

https://github.com/hugovk/termcolor/actions/runs/11531229352/job/32101886048

With cache: 21s

https://github.com/hugovk/termcolor/actions/runs/11531229352/job/32101911080

# tox-dev/action-pre-commit-uv

Without cache: 48s

https://github.com/hugovk/termcolor/actions/runs/11532528002/job/32104427591

With cache: 15s

https://github.com/hugovk/termcolor/actions/runs/11532528002/job/32104447085
