### PR TITLE
Only apply `FORCE_COLOR`, `NO_COLOR` and `ANSI_COLORS_DISABLED` when present and not an empty string

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ In order of precedence:
 
 1. Calling `colored` or `cprint` with a truthy `no_color` disables colour.
 2. Calling `colored` or `cprint` with a truthy `force_color` forces colour.
-3. Setting the `ANSI_COLORS_DISABLED` environment variable to any value disables colour.
+3. Setting the `ANSI_COLORS_DISABLED` environment variable to any non-empty value
+   disables colour.
 4. Setting the [`NO_COLOR`](https://no-color.org/) environment variable to any non-empty
    value disables colour.
 5. Setting the [`FORCE_COLOR`](https://force-color.org/) environment variable to any

--- a/README.md
+++ b/README.md
@@ -99,10 +99,10 @@ In order of precedence:
 1. Calling `colored` or `cprint` with a truthy `no_color` disables colour.
 2. Calling `colored` or `cprint` with a truthy `force_color` forces colour.
 3. Setting the `ANSI_COLORS_DISABLED` environment variable to any value disables colour.
-4. Setting the [`NO_COLOR`](https://no-color.org/) environment variable to any value
-   disables colour.
+4. Setting the [`NO_COLOR`](https://no-color.org/) environment variable to any non-empty
+   value disables colour.
 5. Setting the [`FORCE_COLOR`](https://force-color.org/) environment variable to any
-   value forces colour.
+   non-empty value forces colour.
 6. Setting the `TERM` environment variable to `dumb`, or using such a
    [dumb terminal](https://en.wikipedia.org/wiki/Computer_terminal#Character-oriented_terminal),
    disables colour.

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -120,7 +120,7 @@ def _can_do_colour(
         return True
 
     # Then check env vars:
-    if "ANSI_COLORS_DISABLED" in os.environ:
+    if os.environ.get("ANSI_COLORS_DISABLED"):
         return False
     if os.environ.get("NO_COLOR"):
         return False

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -122,9 +122,9 @@ def _can_do_colour(
     # Then check env vars:
     if "ANSI_COLORS_DISABLED" in os.environ:
         return False
-    if "NO_COLOR" in os.environ:
+    if os.environ.get("NO_COLOR"):
         return False
-    if "FORCE_COLOR" in os.environ:
+    if os.environ.get("FORCE_COLOR"):
         return True
 
     # Then check system:

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -191,15 +191,23 @@ def test_environment_variables_disable_color(
         "false",
         "1",
         "0",
-        "",
     ],
 )
 def test_environment_variables_force_color(
     monkeypatch: pytest.MonkeyPatch, test_value: str
 ) -> None:
-    """Assert color applied when this env var set, regardless of value"""
+    """Assert color applied when this env var is present and not an empty string,
+    regardless of value"""
     monkeypatch.setenv("FORCE_COLOR", test_value)
     assert colored("text", color="cyan") == "\x1b[36mtext\x1b[0m"
+
+
+def test_environment_variables_force_color_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Assert color not applied when empty string"""
+    monkeypatch.setenv("FORCE_COLOR", "")
+    assert colored("text", color="cyan") == "text"
 
 
 @pytest.mark.parametrize(
@@ -208,9 +216,12 @@ def test_environment_variables_force_color(
         # Set only env vars
         (None, None, ["ANSI_COLORS_DISABLED=1"], False),
         (None, None, ["NO_COLOR=1"], False),
+        (None, None, ["NO_COLOR="], False),
         (None, None, ["FORCE_COLOR=1"], True),
+        (None, None, ["FORCE_COLOR="], False),
         (None, None, ["ANSI_COLORS_DISABLED=1", "NO_COLOR=1", "FORCE_COLOR=1"], False),
         (None, None, ["NO_COLOR=1", "FORCE_COLOR=1"], False),
+        (None, None, ["NO_COLOR=1", "FORCE_COLOR="], False),
         (None, None, ["TERM=dumb"], False),
         # Set only parameter overrides
         (True, None, [None], False),

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -215,11 +215,14 @@ def test_environment_variables_force_color_empty_string(
     [
         # Set only env vars
         (None, None, ["ANSI_COLORS_DISABLED=1"], False),
+        (None, None, ["ANSI_COLORS_DISABLED="], False),
         (None, None, ["NO_COLOR=1"], False),
         (None, None, ["NO_COLOR="], False),
         (None, None, ["FORCE_COLOR=1"], True),
         (None, None, ["FORCE_COLOR="], False),
         (None, None, ["ANSI_COLORS_DISABLED=1", "NO_COLOR=1", "FORCE_COLOR=1"], False),
+        (None, None, ["ANSI_COLORS_DISABLED=1", "FORCE_COLOR=1"], False),
+        (None, None, ["ANSI_COLORS_DISABLED=", "FORCE_COLOR=1"], True),
         (None, None, ["NO_COLOR=1", "FORCE_COLOR=1"], False),
         (None, None, ["NO_COLOR=1", "FORCE_COLOR="], False),
         (None, None, ["TERM=dumb"], False),


### PR DESCRIPTION
Similar to the CPython fix: https://github.com/python/cpython/issues/129061 / https://github.com/python/cpython/pull/129140

The `NO_COLOR` spec was changed in 2022:

> Tweak the spec wording to explain that it should be not empty
> "the presence of... when present" was redundant.

https://github.com/jcs/no_color/commit/99f90e27d0fac6a34d07998f8f577e1f2f620c61

It added "and not an empty string" and now reads:

> Command-line software which adds ANSI color to its output by default should check for a ``NO_COLOR`` environment variable that, when present and not an empty string (regardless of its value), prevents the addition of ANSI color.

https://no-color.org/

FORCE_COLOR has similar wording:

> Command-line software which outputs colored text should check for a FORCE_COLOR environment variable. When this variable is present and not an empty string (regardless of its value), it should force the addition of ANSI color.

https://force-color.org/
