### PR TITLE
Remove deprecated `__ALL__`, use `__all__` instead

### DIFF
--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -27,25 +27,10 @@ from __future__ import annotations
 import io
 import os
 import sys
-import warnings
 from collections.abc import Iterable
 from typing import Any
 
 from ._types import Attribute, Color, Highlight
-
-
-def __getattr__(name: str) -> list[str]:
-    if name == "__ALL__":
-        warnings.warn(
-            "__ALL__ is deprecated and will be removed in termcolor 3. "
-            "Use __all__ instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return ["colored", "cprint"]
-    msg = f"module '{__name__}' has no attribute '{name}'"
-    raise AttributeError(msg)
-
 
 ATTRIBUTES: dict[Attribute, int] = {
     "bold": 1,

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -258,9 +258,3 @@ def test_tty(monkeypatch: pytest.MonkeyPatch, test_isatty: bool, expected: str) 
 
     # Act / Assert
     assert colored("text", color="cyan") == expected
-
-
-def test_all_deprecation() -> None:
-    """Assert that __ALL__ is deprecated (use __all__ instead)"""
-    with pytest.deprecated_call():
-        assert termcolor.__ALL__


### PR DESCRIPTION
Was deprecated in https://github.com/termcolor/termcolor/pull/23 in September 2022.