### PR TITLE
Speedup: move typing imports into type-checking block

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,7 +5,9 @@
 exclude_also =
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
+    if TYPE_CHECKING:
 
 [run]
 omit =
     */termcolor/__main__.py
+    */termcolor/_types.py

--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -28,10 +28,13 @@ import io
 import os
 import sys
 import warnings
-from collections.abc import Iterable
-from typing import Any
 
-from ._types import Attribute, Color, Highlight
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
+
+    from ._types import Attribute, Color, Highlight
 
 
 def __getattr__(name: str) -> list[str]:

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Iterable
-from typing import Any
 
 import pytest
 
 from termcolor import ATTRIBUTES, COLORS, HIGHLIGHTS, colored, cprint, termcolor
-from termcolor._types import Attribute, Color, Highlight
+
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Any
+
+    from termcolor._types import Attribute, Color, Highlight
 
 ALL_COLORS = [*COLORS, None]
 ALL_HIGHLIGHTS = [*HIGHLIGHTS, None]


### PR DESCRIPTION
Speeds up imports when not running mypy.


# Before

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/ae2f8bbd-e3bd-4173-845b-d2220a9ae3ee" />

# After

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/717533a2-87f0-4cea-8ebf-18196837a847" />
