### PR TITLE
Advertise typing via classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Terminals",
+  "Typing :: Typed",
 ]
 dynamic = [ "version" ]
 optional-dependencies.tests = [


### PR DESCRIPTION
Type hints were added in fb014068c2d7d967e40e95d92c0a33e2c97dc140 Adding the classifier helps advertise the status on PyPI.