### PR TITLE
Cache system lookups to save invocation time

### DIFF
--- a/src/termcolor/termcolor.py
+++ b/src/termcolor/termcolor.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import io
 import os
 import sys
+from functools import cache
 
 TYPE_CHECKING = False
 if TYPE_CHECKING:
@@ -88,6 +89,7 @@ COLORS: dict[str, int] = {
 RESET = "\033[0m"
 
 
+@cache
 def _can_do_colour(
     *, no_color: bool | None = None, force_color: bool | None = None
 ) -> bool:


### PR DESCRIPTION
Caching the output of the lookups performed drops time from 3-5 milliseconds to hundreds of nanoseconds, as calls to `os.environ` and other system indicators are unlikely to change within the course of a running process.

Using the `cache` decorator allows for passing in `no_color/force_color` params to change the desired behavior, while allowing the text and colors to be different without increasing the cache size.

Resolves #48