### PR TITLE
Test code branches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ max_supported_python = "3.14"
 testpaths = [ "tests" ]
 
 [tool.coverage.run]
+branch = true
 disable_warnings = [
   "no-sysmon",
 ]

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -93,6 +93,7 @@ def assert_cprint(
         ("light_blue", "\x1b[94mtext\x1b[0m"),
         ((1, 2, 3), "\x1b[38;2;1;2;3mtext\x1b[0m"),
         ((100, 200, 150), "\x1b[38;2;100;200;150mtext\x1b[0m"),
+        (000, "text\x1b[0m"),  # invalid input type
     ],
 )
 def test_color(
@@ -128,6 +129,7 @@ def test_color(
         ("on_light_blue", "\x1b[104mtext\x1b[0m"),
         ((1, 2, 3), "\x1b[48;2;1;2;3mtext\x1b[0m"),
         ((100, 200, 150), "\x1b[48;2;100;200;150mtext\x1b[0m"),
+        (000, "text\x1b[0m"),  # invalid input type
     ],
 )
 def test_on_color(


### PR DESCRIPTION
Branch coverage exposed two conditions that were never untrue.

This happens if an invalid input type is passed, and the code currently returns the input + the reset value.