### PR TITLE
Add mutation testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# Mutation Testing artifacts
+mutants/

--- a/tests/test_termcolor.py
+++ b/tests/test_termcolor.py
@@ -357,3 +357,31 @@ def test_unsupported_operation(
 
     # Act / Assert
     assert colored("text", color="cyan") == expected
+
+
+@pytest.mark.parametrize(
+    "isatty_value, expected, kwargs",
+    [
+        # no_color when isatty
+        (True, "text", {"no_color": True}),
+        # force_color when not isatty
+        (False, "\x1b[36mtext\x1b[0m", {"force_color": True}),
+        # print kwargs pass through
+        (True, "\x1b[36mtext\x1b[0m!", {"end": "!\n"}),
+    ],
+)
+def test_cprint_kwargs(
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+    isatty_value: bool,
+    expected: str,
+    kwargs: dict[str, Any],
+) -> None:
+    """Test cprint with various parameter combinations"""
+    # Arrange
+    monkeypatch.setattr(os, "isatty", lambda fd: isatty_value)
+    monkeypatch.setattr("sys.stdout.isatty", lambda: isatty_value)
+    monkeypatch.setattr("sys.stdout.fileno", lambda: 1)
+
+    # Act / Assert
+    assert_cprint(capsys, expected, "text", color="cyan", **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ requires =
     tox>=4.2
 env_list =
     lint
+    mutmut
     py{py3, 314, 313, 312, 311, 310, 39}
 
 [testenv]
@@ -30,3 +31,11 @@ pass_env =
     PRE_COMMIT_COLOR
 commands =
     pre-commit run --all-files --show-diff-on-failure
+
+[testenv:mutmut]
+deps =
+    mutmut
+extras =
+    tests
+commands =
+    mutmut {posargs:run}


### PR DESCRIPTION
Run with:

    uvx --with tox-uv tox -e mutmut

Enter interactive browsing with:

    uvx --with tox-uv tox -e mutmut -- browse

Ref: https://mutmut.readthedocs.io/

Signed-off-by: Mike Fiedler <miketheman@gmail.com>