### PR TITLE
Test free-threaded Python 3.13t and 3.14t

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ permissions: {}
 
 env:
   FORCE_COLOR: 1
+  PIP_DISABLE_PIP_VERSION_CHECK: 1
 
 jobs:
   test:
@@ -13,7 +14,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["pypy3.11", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version:
+          - "pypy3.11"
+          - "3.14t"
+          - "3.14"
+          - "3.13t"
+          - "3.13"
+          - "3.12"
+          - "3.11"
+          - "3.10"
+          - "3.9"
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:
@@ -27,14 +37,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
 
+      - name: Set PYTHON_GIL
+        if: endsWith(matrix.python-version, 't')
+        run: |
+          echo "PYTHON_GIL=0" >> "$GITHUB_ENV"
+
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
-        with:
-          cache-dependency-glob: "**/pyproject.toml"
+        uses: astral-sh/setup-uv@v6
 
       - name: Tox tests
         run: |
-          uvx --with tox-uv tox -e py
+          uvx --python ${{ matrix.python-version }} --with tox-uv tox -e py
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
3.14 and free-threaded earlier, because they're not always in the setup-python image cache and can take a couple of minutes to set up, so give them a head start.