### PR TITLE
fix: exclude tests dir from sdist and wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ version.source = "vcs"
 local_scheme = "no-local-version"
 
 [tool.hatch.build.targets.wheel]
-exclude = [ "test" ]
+exclude = [ "tests" ]
 
 [tool.hatch.build.targets.sdist]
 exclude = [ "tests" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ optional-dependencies.tests = [
 urls.Changelog = "https://github.com/termcolor/termcolor/releases"
 urls.Homepage = "https://github.com/termcolor/termcolor"
 urls.Source = "https://github.com/termcolor/termcolor"
+exclude = ["tests"]
 
 [tool.hatch]
 version.source = "vcs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,13 +50,18 @@ optional-dependencies.tests = [
 urls.Changelog = "https://github.com/termcolor/termcolor/releases"
 urls.Homepage = "https://github.com/termcolor/termcolor"
 urls.Source = "https://github.com/termcolor/termcolor"
-exclude = [ "tests" ]
 
 [tool.hatch]
 version.source = "vcs"
 
 [tool.hatch.version.raw-options]
 local_scheme = "no-local-version"
+
+[tool.hatch.build.targets.wheel]
+exclude = [ "test" ]
+
+[tool.hatch.build.targets.sdist]
+exclude = [ "tests" ]
 
 [tool.ruff]
 fix = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ optional-dependencies.tests = [
 urls.Changelog = "https://github.com/termcolor/termcolor/releases"
 urls.Homepage = "https://github.com/termcolor/termcolor"
 urls.Source = "https://github.com/termcolor/termcolor"
-exclude = ["tests"]
+exclude = [ "tests" ]
 
 [tool.hatch]
 version.source = "vcs"


### PR DESCRIPTION
When installing one of my own libs I noticed a warning saying termcolor/tests was being unpacked into site-packages over an existing directory. I don't believe you intend to include the tests with your build. This PR fixes that.