### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,6 @@ jobs:
           - "3.12"
           - "3.11"
           - "3.10"
-          - "3.9"
         os: [windows-latest, macos-latest, ubuntu-latest]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ license = "MIT"
 license-files = [ "COPYING.txt" ]
 maintainers = [ { name = "Hugo van Kemenade" } ]
 authors = [ { name = "Konstantin Lepa", email = "konstantin.lepa@gmail.com" } ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -31,7 +31,6 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ requires =
 env_list =
     lint
     mutmut
-    py{py3, 314, 313, 312, 311, 310, 39}
+    py{py3, 314, 313, 312, 311, 310}
 
 [testenv]
 extras =


### PR DESCRIPTION
It's almost end-of-life:

* https://devguide.python.org/versions/
* https://peps.python.org/pep-0596/
