### PR TITLE
Add GitHub code coverage

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# TODO Remove when actionlint knows the code-quality permission scope:
+# https://github.com/rhysd/actionlint/issues/672
+paths:
+  .github/workflows/test.yml:
+    ignore:
+      - 'unknown permission scope "code-quality"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ env:
 
 jobs:
   test:
+    permissions:
+      code-quality: write
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -54,6 +56,14 @@ jobs:
         with:
           flags: ${{ matrix.os }}
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
+
+      - name: Upload coverage report
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1 # v1.4.1
+        with:
+          file: coverage.xml
+          language: python
+          label: code-coverage/pytest
 
   success:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,10 @@ jobs:
           name: ${{ matrix.os }} Python ${{ matrix.python-version }}
 
       - name: Upload coverage report
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: |
+          github.ref == 'refs/heads/main' ||
+          (github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1 # v1.4.1
         with:
           file: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,9 +59,12 @@ jobs:
 
       - name: Upload coverage report
         if: |
-          github.ref == 'refs/heads/main' ||
-          (github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository)
+          (github.event_name == 'push'
+           && github.ref == 'refs/heads/main'
+           && github.event.repository.fork == false)
+          ||
+          (github.event_name == 'pull_request'
+           && github.event.pull_request.head.repo.full_name == github.repository)
         uses: actions/upload-code-coverage@1c15be36fc3733ba839b1dd643bd9556e4426dc1 # v1.4.1
         with:
           file: coverage.xml


### PR DESCRIPTION
* https://github.blog/changelog/2026-07-20-github-code-quality-is-now-generally-available/
* https://docs.github.com/en/code-security/how-tos/maintain-quality-code/set-up-code-coverage

Unfortunately this is quite limited and not ready to replace Codecov:

* Only available in org-based repos, not username-based
* Only works on pushes to `main` and for PRs
* Only works on PRs from the same repo, not from forks

Also pending https://github.com/rhysd/actionlint/issues/672 to remove actionlint workaround.
